### PR TITLE
preliminary manual setup to establish a docker slurm cluster

### DIFF
--- a/docker-slurm-on-slaves.md
+++ b/docker-slurm-on-slaves.md
@@ -1,0 +1,49 @@
+# Testing the mvdbeek/galaxy-slurm docker container
+
+available in [Docker Registry](https://hub.docker.com/r/mvdbeek/galaxy-slurm/)
+
+
+## set up a docker network with master and slave nodes
+
+the script net.sh:
+
+
+
+### node 0
+```
+#!/usr/bin/env bash
+docker network create -d macvlan \
+    --subnet=192.168.2.0/24 \
+    --gateway=192.168.2.123  \ # this value on the node 0 should be clarified
+    -o parent=eth0 slurm-net    
+```
+### node 1
+```
+docker network create -d macvlan \
+    --subnet=192.168.2.0/24 \
+    --gateway=192.168.2.251  \
+    -o parent=eth0 slurm-net
+```
+
+
+## Install scripts in the /home/galaxy/galaxy-slurm folder
+
+
+
+### slurm.conf
+
+Edit `/etc/slurm-llnl/slurm.conf`
+
+and add:
+```
+NodeName=mississippi-node-0 CPUs=2 RealMemory=7479 State=UNKNOWN
+NodeName=mississippi-node-1 CPUs=2 RealMemory=7479 State=UNKNOWN
+PartitionName=debug Nodes=mississippi-node-0,mississippi-node-1 Default=YES MaxTime=INFINITE State=UP Shared=YES
+```
+
+and
+
+copy: `cp /etc/slurm-llnl/slurm.conf /home/galaxy/galaxy/`
+
+and see the new nfs export and mount in /etc/fstab
+

--- a/scripts/galaxy-slurm/mount_nfs.sh
+++ b/scripts/galaxy-slurm/mount_nfs.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sudo mount -t nfs4 -o proto=tcp,port=2049 10.132.0.2:/ /home/galaxy/galaxy-slurm/galaxy-slurm-data
+

--- a/scripts/galaxy-slurm/net.sh
+++ b/scripts/galaxy-slurm/net.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+docker network create -d macvlan \
+    --subnet=10.132.0.0/24 \
+    --gateway=10.132.0.1  \
+    -o parent=virtual2 slurm-net

--- a/scripts/galaxy-slurm/start_slurm.sh
+++ b/scripts/galaxy-slurm/start_slurm.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# This script requires the slurm-net docker network,
+# which bridges a docker network to a physical network adapter (eth0 in this case)
+## # Macvlan  (-o macvlan_mode= Defaults to Bridge mode if not specified)
+# On slave node-1
+# docker network create -d macvlan \
+#     --subnet=192.168.2.0/24 \
+#     --gateway=192.168.2.251  \
+#     -o parent=eth0 slurm-net
+
+
+HOSTNAME=mississippi-node-1
+IP=192.168.2.60
+NET=slurm-net
+docker run -d \
+       --name slurm \
+       --privileged \
+       --net "$NET" \
+       --add-host 'mississippi-node-0:192.168.2.60' \
+       --add-host 'mississippi-node-1:192.168.2.61' \
+       --add-host 'mississippi-node-0:192.168.2.254' \
+       --ip "$IP" \
+       --hostname "$HOSTNAME" \
+       -e "SLURMCTLD_AUTOSTART=false" \
+       -e "ADD_SLURM_USER_TO_DOCKER_GROUP=true" \
+       -e "DOCKER_AUTOSTART=true" \
+       -e "GALAXY_DIR=/export/galaxy/" \
+       -e "SYMLINK_TARGET=/home/galaxy" \
+       -e "SLURM_UID=1002" \
+       -e "SLURM_GID=1002" \
+       -e "MUNGE_KEY_PATH=/export/galaxy/munge.key" \
+       -e "SLURM_CONF_PATH=/export/galaxy/slurm.conf" \
+       -v /home/galaxy/galaxy-slurm/galaxy-slurm-data/:/export \
+       -v /home/galaxy/galaxy-slurm/galaxy-slurm-data/tmp:/var/storage/tmp \
+       -v /home/galaxy/galaxy-slurm/galaxy-slurm-data/job_working_directory:/var/storage/job_working_directory \
+       -v /home/galaxy/galaxy-slurm/galaxy-slurm-data/files:/var/storage/files \
+       -v /home/galaxy/galaxy-slurm/galaxy-slurm-data/ftp:/var/storage/ftp \
+       mvdbeek/galaxy-slurm
+

--- a/setup_nfs.md
+++ b/setup_nfs.md
@@ -10,7 +10,7 @@ Note that the /export directory will be filled by GalaxyKickStart if it is creat
 - For server machine, `apt-get install nfs-kernel-server nfs-common`
 - For client machine (to be set later) `apt-get install nfs-common`
 
-### On server side
+### On server side (node 0)
 - `apt-get install nfs-kernel-server nfs-common`
 - Edit `/etc/exports` and add the lines
 
@@ -24,6 +24,9 @@ Note that the /export directory will be filled by GalaxyKickStart if it is creat
 /export/etc/postgresql/9.3/main 10.132.0.0/24(rw,nohide,insecure,no_subtree_check)
 ```
 
+- for docker-slurm, manually add to /etc/exports :
+`/export/galaxy 10.132.0.0/24(rw,nohide,insecure,no_subtree_check)`
+
 *note that bad ip range syntax cause problem initially (was 10.132.0.2/255.255.255.255)*
 
 - Be aware of the add-in in /etc/fstab file triggered by GKS
@@ -35,6 +38,9 @@ Note that the /export directory will be filled by GalaxyKickStart if it is creat
 /export//home/galaxy/galaxy/database /home/galaxy/galaxy/database none bind 0 0
 /export//etc/postgresql/9.3/main /etc/postgresql/9.3/main none bind 0 0
 ```
+
+- for docker-slurm, manually add to /etc/fstab:
+`/export/home/galaxy /home/galaxy none bind 0 0` (maybe not necessary if just playing with nfs sharing, `to be tested`; in any case, the mounting point /export/home/galaxy is created by GKG) 
 
 - Be aware of the export mechanism triggered by GKG when it found an /export directory (move.data role executed when this directory is present on the system)
 ```


### PR DESCRIPTION
 - GKS crashed (supervisorctl does not find .venv anymore at first glance